### PR TITLE
Remove leading space from keywords.txt identifier

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -3,23 +3,23 @@
 #######################################
 
 #######################################
-# Instance				(KEYWORD1)
+# Instance	(KEYWORD1)
 #######################################
 
-PB04					 KEYWORD1
+PB04	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin   				 KEYWORD2
-getVoltage   			 KEYWORD2
-getCurrent	  		 	 KEYWORD2
-getPower			 	 KEYWORD2
-poll					 KEYWORD2
+begin	KEYWORD2
+getVoltage	KEYWORD2
+getCurrent	KEYWORD2
+getPower	KEYWORD2
+poll	KEYWORD2
 
 #######################################
-# Constants 			(LITERAL1)
+# Constants	(LITERAL1)
 #######################################
 
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords