### PR TITLE
Populate library.properties url field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,5 +5,5 @@ maintainer=XINABOX <support@xinabox.cc>
 sentence=Simple library to interface Smart Battery Module
 paragraph=Simple library to interface Smart Battery Module
 category=Sensors
-url=*
+url=https://github.com/xinabox/xPB04
 architectures=*


### PR DESCRIPTION
A empty url field results in an apparently clickable "More info" link in Library Manager that does nothing.